### PR TITLE
Fix profile link for Maira

### DIFF
--- a/src/index.soy
+++ b/src/index.soy
@@ -108,7 +108,7 @@
             [
               'name': 'Maira Bello',
               'image': 'https://2.gravatar.com/avatar/97e0e62c9c02badba4c321f7613e6acf?size=50',
-              'url': 'mairatma'
+              'url': 'https://github.com/mairatma'
             ]
           ] /}
         {/call}


### PR DESCRIPTION
Currently is relative pointing to `mairatma`, and there's no `http://trackingjs.com/mairatma`. 

I followed the other profiles linking to respective github accs.
