### PR TITLE
docs($typo): web-components section typos

### DIFF
--- a/src/docs.soy
+++ b/src/docs.soy
@@ -542,7 +542,7 @@ var descriptors2 = tracking.Brief.getDescriptors(pixels, width, corners2);</code
         </p>
 
         <p>
-          Can you imagine tag your friends face in a picture with one line of HTML? Or, to track an user face with the same API? This section will show how you can do that. This will require <a href="http://bower.io" target="_blank">Bower</a> — a front end package manager. Once you have bower installed, install tracking-elements:
+          Can you imagine tagging your friend's face in a picture with one line of HTML? Or, tracking a user's face with the same API? This section will show how you can do that. This will require <a href="http://bower.io" target="_blank">Bower</a> — a front end package manager. Once you have bower installed, install tracking-elements:
         </p>
 
         {literal}


### PR DESCRIPTION
Fixed a couple grammar mistakes in the web-components section.  
