### PR TITLE
Fix Mixed Content Error

### DIFF
--- a/src/examples/color_hexgl.soy
+++ b/src/examples/color_hexgl.soy
@@ -9,7 +9,7 @@
 {call example.page}
   {param pageName: 'Racing Car' /}
   {param baseDir: '../' /}
-  {param url: 'http://pablocp.github.io/HexGL/' /}
+  {param url: 'https://pablocp.github.io/HexGL/' /}
   {param sourceUrl: 'https://github.com/pablocp/HexGL/' /}
   {param cssScope: 'color_hexgl' /}
 {/call}


### PR DESCRIPTION
```
Mixed Content: The page at 'https://trackingjs.com/examples/color_hexgl.html' was loaded over HTTPS, but requested an insecure resource 'http://pablocp.github.io/HexGL/'. This request has been blocked; the content must be served over HTTPS.
```